### PR TITLE
Fix .gitignore to exclude unnecessary /engine/build/ folder from the …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ com_crashlytics_export_strings.xml
 /html/build/
 /ios/build/
 /ios-moe/build/
+/engine/build/
 
 /nbbuild/
 /android/nbbuild/


### PR DESCRIPTION
The aforementioned folder could be safely ignored, thus added to the .gitignore file.